### PR TITLE
fix typo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ column3 name: bar-bar
 
 ## Install
 ```
-$ embukl gem install embulk-filter-rename_with_gsub
+$ embulk gem install embulk-filter-rename_with_gsub
 ```
 
 ## Preview


### PR DESCRIPTION
Hi, sesame.
Thank you for your developments.
I frequently use your gems for embulk.

I find typo in your `README.md` at install section, and I guess fix.
If you like this fix, please merge this pull-req, please

Thank you!